### PR TITLE
Fixes bug with initial bounding box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,36 @@
-# 0.1.12
+# Changelog
+
+## 0.1.12
+
+- Fix bug with initial bounds.
+
+## 0.1.12
 
 - Fix bug with bounds handle events.
 
-# 0.1.11
+## 0.1.11
 
 - Fix bug with initial camera state.
 
-# 0.1.10
+## 0.1.10
 
 - Improve example.
 - Improve types for `TLPage`.
 
-# 0.1.9
+## 0.1.9
 
 - Bug fixes.
 
-# 0.1.8
+## 0.1.8
 
 - Expands README.
 - Removes properties specific to the TLDraw app.
 
-# 0.1.7
+## 0.1.7
 
 - Fixes selection bug with SVGContainer.
 - Removes various properties specific to the TLDraw app.
 
-# 0.1.0
+## 0.1.0
 
 - Re-writes API for ShapeUtils.

--- a/packages/core/src/components/canvas/canvas.test.tsx
+++ b/packages/core/src/components/canvas/canvas.test.tsx
@@ -14,6 +14,7 @@ describe('page', () => {
         hideBindingHandles={false}
         hideCloneHandles={false}
         hideRotateHandle={false}
+        onBoundsChange={(bounds) => {}}
       />
     )
   })

--- a/packages/core/src/components/canvas/canvas.tsx
+++ b/packages/core/src/components/canvas/canvas.tsx
@@ -8,7 +8,7 @@ import {
   useCameraCss,
   useKeyEvents,
 } from '~hooks'
-import type { TLBinding, TLPage, TLPageState, TLShape, TLSnapLine, TLUsers } from '~types'
+import type { TLBinding, TLBounds, TLPage, TLPageState, TLShape, TLSnapLine, TLUsers } from '~types'
 import { ErrorFallback } from '~components/error-fallback'
 import { ErrorBoundary } from '~components/error-boundary'
 import { Brush } from '~components/brush'
@@ -39,6 +39,7 @@ interface CanvasProps<T extends TLShape, M extends Record<string, unknown>> {
   externalContainerRef?: React.RefObject<HTMLElement>
   meta?: M
   id?: string
+  onBoundsChange: (bounds: TLBounds) => void
 }
 
 export function Canvas<T extends TLShape, M extends Record<string, unknown>>({
@@ -56,6 +57,7 @@ export function Canvas<T extends TLShape, M extends Record<string, unknown>>({
   hideBindingHandles,
   hideCloneHandles,
   hideRotateHandle,
+  onBoundsChange,
 }: CanvasProps<T, M>): JSX.Element {
   const rCanvas = React.useRef<HTMLDivElement>(null)
   const rContainer = React.useRef<HTMLDivElement>(null)
@@ -63,13 +65,13 @@ export function Canvas<T extends TLShape, M extends Record<string, unknown>>({
 
   inputs.zoom = pageState.camera.zoom
 
-  useResizeObserver(rCanvas)
+  useResizeObserver(rCanvas, onBoundsChange)
 
   useZoomEvents(pageState.camera.zoom, externalContainerRef || rCanvas)
 
   useSafariFocusOutFix()
 
-  usePreventNavigation(rCanvas, inputs.bounds.width)
+  usePreventNavigation(rCanvas)
 
   useCameraCss(rLayer, rContainer, pageState)
 

--- a/packages/core/src/components/page/page.tsx
+++ b/packages/core/src/components/page/page.tsx
@@ -35,16 +35,9 @@ export const Page = React.memo(function Page<T extends TLShape, M extends Record
   hideRotateHandle,
   meta,
 }: PageProps<T, M>): JSX.Element {
-  const { callbacks, shapeUtils, inputs } = useTLContext()
+  const { bounds: rendererBounds, shapeUtils, inputs } = useTLContext()
 
-  const shapeTree = useShapeTree(
-    page,
-    pageState,
-    shapeUtils,
-    [inputs.bounds.width, inputs.bounds.height],
-    meta,
-    callbacks.onRenderCountChange
-  )
+  const shapeTree = useShapeTree(page, pageState, meta)
 
   const { bounds, isLinked, isLocked, rotation } = useSelection(page, pageState, shapeUtils)
 
@@ -95,7 +88,7 @@ export const Page = React.memo(function Page<T extends TLShape, M extends Record
         <Bounds
           zoom={zoom}
           bounds={bounds}
-          viewportWidth={inputs.bounds.width}
+          viewportWidth={rendererBounds.width}
           isLocked={isLocked}
           rotation={rotation}
           isHidden={hideBounds}

--- a/packages/core/src/components/renderer/renderer.tsx
+++ b/packages/core/src/components/renderer/renderer.tsx
@@ -128,13 +128,28 @@ export function Renderer<T extends TLShape, M extends Record<string, unknown>>({
     rPageState.current = pageState
   }, [pageState])
 
-  const [context] = React.useState<TLContextType<T>>(() => ({
+  const [context, setContext] = React.useState<TLContextType<T>>(() => ({
     callbacks: rest,
     shapeUtils,
     rSelectionBounds,
     rPageState,
+    bounds: {
+      minX: 0,
+      minY: 0,
+      maxX: Infinity,
+      maxY: Infinity,
+      width: Infinity,
+      height: Infinity,
+    },
     inputs: new Inputs(),
   }))
+
+  const onBoundsChange = React.useCallback((bounds: TLBounds) => {
+    setContext((context) => ({
+      ...context,
+      bounds,
+    }))
+  }, [])
 
   return (
     <TLContext.Provider value={context as unknown as TLContextType<TLShape>}>
@@ -152,6 +167,7 @@ export function Renderer<T extends TLShape, M extends Record<string, unknown>>({
         hideCloneHandles={hideCloneHandles}
         hideBindingHandles={hideBindingHandles}
         hideRotateHandle={hideRotateHandles}
+        onBoundsChange={onBoundsChange}
         meta={meta}
       />
     </TLContext.Provider>

--- a/packages/core/src/hooks/useCameraCss.tsx
+++ b/packages/core/src/hooks/useCameraCss.tsx
@@ -4,7 +4,7 @@ import type { TLPageState } from '~types'
 
 export function useCameraCss(
   layerRef: React.RefObject<HTMLDivElement>,
-  containerRef: React.RefObject<HTMLDivElement>,
+  containerRef: React.ForwardedRef<HTMLDivElement>,
   pageState: TLPageState
 ) {
   // Update the tl-zoom CSS variable when the zoom changes
@@ -22,21 +22,23 @@ export function useCameraCss(
 
     if (didZoom || didPan) {
       const layer = layerRef.current
-      const container = containerRef.current
+      if (containerRef && 'current' in containerRef) {
+        const container = containerRef.current
 
-      // If we zoomed, set the CSS variable for the zoom
-      if (didZoom) {
-        if (container) {
-          container.style.setProperty('--tl-zoom', zoom.toString())
+        // If we zoomed, set the CSS variable for the zoom
+        if (didZoom) {
+          if (container) {
+            container.style.setProperty('--tl-zoom', zoom.toString())
+          }
         }
-      }
 
-      // Either way, position the layer
-      if (layer) {
-        layer.style.setProperty(
-          'transform',
-          `scale(${zoom}) translateX(${point[0]}px) translateY(${point[1]}px)`
-        )
+        // Either way, position the layer
+        if (layer) {
+          layer.style.setProperty(
+            'transform',
+            `scale(${zoom}) translateX(${point[0]}px) translateY(${point[1]}px)`
+          )
+        }
       }
     }
   }, [pageState.camera])

--- a/packages/core/src/hooks/usePreventNavigation.tsx
+++ b/packages/core/src/hooks/usePreventNavigation.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import * as React from 'react'
+import { useTLContext } from '~hooks'
 
-export function usePreventNavigation(
-  rCanvas: React.RefObject<HTMLDivElement>,
-  width: number
-): void {
+export function usePreventNavigation(rCanvas: React.RefObject<HTMLDivElement>): void {
+  const { bounds } = useTLContext()
+
   React.useEffect(() => {
     const preventGestureNavigation = (event: TouchEvent) => {
       event.preventDefault()
@@ -20,7 +20,7 @@ export function usePreventNavigation(
       // if the touch area overlaps with the screen edges
       // it's likely to trigger the navigation. We prevent the
       // touchstart event in that case.
-      if (touchXPosition - touchXRadius < 10 || touchXPosition + touchXRadius > width - 10) {
+      if (touchXPosition - touchXRadius < 10 || touchXPosition + touchXRadius > bounds.width - 10) {
         event.preventDefault()
       }
     }
@@ -56,5 +56,5 @@ export function usePreventNavigation(
         elm.removeEventListener('touchstart', preventNavigation)
       }
     }
-  }, [rCanvas, width])
+  }, [rCanvas, bounds.width])
 }

--- a/packages/core/src/hooks/useTLContext.tsx
+++ b/packages/core/src/hooks/useTLContext.tsx
@@ -11,6 +11,7 @@ export interface TLContextType<T extends TLShape> {
   rPageState: React.MutableRefObject<TLPageState>
   rSelectionBounds: React.MutableRefObject<TLBounds | null>
   inputs: Inputs
+  bounds: TLBounds
 }
 
 export const TLContext = React.createContext({} as TLContextType<TLShape>)

--- a/packages/core/src/hooks/useZoomEvents.ts
+++ b/packages/core/src/hooks/useZoomEvents.ts
@@ -11,7 +11,7 @@ export function useZoomEvents<T extends HTMLElement>(zoom: number, ref: React.Re
   const rPinchPoint = React.useRef<number[] | undefined>(undefined)
   const rDelta = React.useRef<number[]>([0, 0])
 
-  const { inputs, callbacks } = useTLContext()
+  const { inputs, bounds, callbacks } = useTLContext()
 
   React.useEffect(() => {
     const preventGesture = (event: TouchEvent) => {
@@ -35,7 +35,7 @@ export function useZoomEvents<T extends HTMLElement>(zoom: number, ref: React.Re
     {
       onWheel: ({ delta, event: e }) => {
         if (e.altKey && e.buttons === 0) {
-          const point = inputs.pointer?.point ?? [inputs.bounds.width / 2, inputs.bounds.height / 2]
+          const point = inputs.pointer?.point ?? [bounds.width / 2, bounds.height / 2]
 
           const info = inputs.pinch(point, point)
 

--- a/packages/core/src/shape-utils/TLShapeUtil.tsx
+++ b/packages/core/src/shape-utils/TLShapeUtil.tsx
@@ -27,7 +27,7 @@ export abstract class TLShapeUtil<T extends TLShape, E extends Element = any, M 
 
   abstract getBounds: (shape: T) => TLBounds
 
-  shouldRender: (prev: T, next: T) => boolean = () => true
+  shouldRender = (prev: T, next: T): boolean => true
 
   getRef = (shape: T): React.RefObject<E> => {
     if (!this.refMap.has(shape.id)) {

--- a/packages/core/src/test/context-wrapper.tsx
+++ b/packages/core/src/test/context-wrapper.tsx
@@ -2,20 +2,30 @@ import * as React from 'react'
 import type { TLPageState, TLBounds } from '../types'
 import { mockDocument } from './mockDocument'
 import { mockUtils } from './mockUtils'
-import { useTLTheme, TLContext } from '../hooks'
+import { useTLTheme, TLContext, TLContextType } from '../hooks'
 import { Inputs } from '~inputs'
+import type { TLShape } from '~index'
+import type { BoxShape } from '~shape-utils/TLShapeUtil.spec'
 
 export const ContextWrapper: React.FC = ({ children }) => {
   useTLTheme()
   const rSelectionBounds = React.useRef<TLBounds>(null)
   const rPageState = React.useRef<TLPageState>(mockDocument.pageState)
 
-  const [context] = React.useState(() => ({
+  const [context] = React.useState<TLContextType<BoxShape>>(() => ({
     callbacks: {},
     shapeUtils: mockUtils,
     rSelectionBounds,
     rPageState,
     inputs: new Inputs(),
+    bounds: {
+      minX: 0,
+      minY: 0,
+      maxX: Infinity,
+      maxY: Infinity,
+      width: Infinity,
+      height: Infinity,
+    },
   }))
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR fixes a bug where the memoized Page component was not updating to reflect changes to the bounding box, which caused certain shapes to be incorrectly flagged as "off-screen" on first render.