### PR TITLE
[feature] `hideResizeHandles`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.20
+
+- Update docs.
+- Adds `hideResizeHandles` prop.
+
 ## 0.1.19
 
 - Remove stray `index.js` files.

--- a/README.md
+++ b/README.md
@@ -87,19 +87,20 @@ To avoid unnecessary renders, be sure to pass "stable" values as props to the `R
 | `pageState`  | [`TLPageState`](#tlpagestate)   | The current page's state.                      |
 | `shapeUtils` | [`TLShapeUtils`](#tlshapeutils) | The shape utilities used to render the shapes. |
 
-In addition to these required props, the Renderer accents many optional props.
+In addition to these required props, the Renderer accents many other **optional** props.
 
-| Property             | Type                          | Description                                                            |
-| -------------------- | ----------------------------- | ---------------------------------------------------------------------- |
-| `containerRef`       | `React.MutableRefObject`      | A React ref for the container, where CSS variables will be added.      |
-| `theme`              | `object`                      | (optional) an object with overrides for the Renderer's default colors. |
-| `hideBounds`         | `boolean`                     | (optional) an object with overrides for the Renderer's default colors. |
-| `hideHandles`        | `boolean`                     | (optional) an object with overrides for the Renderer's default colors. |
-| `hideBindingHandles` | `boolean`                     | (optional) an object with overrides for the Renderer's default colors. |
-| `hideRotateHandles`  | `boolean`                     | (optional) an object with overrides for the Renderer's default colors. |
-| `snapLines`          | [`TLSnapLine`](#tlsnapline)[] | (optional) an object with overrides for the Renderer's default colors. |
-| `users`              | `TLUser`                      | (optional) an object with overrides for the Renderer's default colors. |
-| `userId`             | `object`                      | (optional) an object with overrides for the Renderer's default colors. |
+| Property             | Type                          | Description                                                       |
+| -------------------- | ----------------------------- | ----------------------------------------------------------------- |
+| `containerRef`       | `React.MutableRefObject`      | A React ref for the container, where CSS variables will be added. |
+| `theme`              | `object`                      | An object with overrides for the Renderer's default colors.       |
+| `hideBounds`         | `boolean`                     | Do not show the bounding box for selected shapes.                 |
+| `hideHandles`        | `boolean`                     | Do not show handles for shapes with handles.                      |
+| `hideBindingHandles` | `boolean`                     | Do not show binding controls for selected shapes with bindings.   |
+| `hideResizeHandles`  | `boolean`                     | Do not show resize handles for selected shapes.                   |
+| `hideRotateHandles`  | `boolean`                     | Do not show rotate handles for selected shapes.                   |
+| `snapLines`          | [`TLSnapLine`](#tlsnapline)[] | An array of "snap" lines.                                         |
+| `users`              | `object`                      | A table of [`TLUser`](#tluser)s.                                  |
+| `userId`             | `object`                      | The current user's [`TLUser`](#tluser) id.                        |
 
 The theme object accepts valid CSS colors for the following properties:
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.20
+
+- Update docs.
+- Adds `hideResizeHandles` prop.
+
 ## 0.1.19
 
 - Remove stray `index.js` files.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -87,19 +87,20 @@ To avoid unnecessary renders, be sure to pass "stable" values as props to the `R
 | `pageState`  | [`TLPageState`](#tlpagestate)   | The current page's state.                      |
 | `shapeUtils` | [`TLShapeUtils`](#tlshapeutils) | The shape utilities used to render the shapes. |
 
-In addition to these required props, the Renderer accents many optional props.
+In addition to these required props, the Renderer accents many other **optional** props.
 
-| Property             | Type                          | Description                                                            |
-| -------------------- | ----------------------------- | ---------------------------------------------------------------------- |
-| `containerRef`       | `React.MutableRefObject`      | A React ref for the container, where CSS variables will be added.      |
-| `theme`              | `object`                      | (optional) an object with overrides for the Renderer's default colors. |
-| `hideBounds`         | `boolean`                     | (optional) an object with overrides for the Renderer's default colors. |
-| `hideHandles`        | `boolean`                     | (optional) an object with overrides for the Renderer's default colors. |
-| `hideBindingHandles` | `boolean`                     | (optional) an object with overrides for the Renderer's default colors. |
-| `hideRotateHandles`  | `boolean`                     | (optional) an object with overrides for the Renderer's default colors. |
-| `snapLines`          | [`TLSnapLine`](#tlsnapline)[] | (optional) an object with overrides for the Renderer's default colors. |
-| `users`              | `TLUser`                      | (optional) an object with overrides for the Renderer's default colors. |
-| `userId`             | `object`                      | (optional) an object with overrides for the Renderer's default colors. |
+| Property             | Type                          | Description                                                       |
+| -------------------- | ----------------------------- | ----------------------------------------------------------------- |
+| `containerRef`       | `React.MutableRefObject`      | A React ref for the container, where CSS variables will be added. |
+| `theme`              | `object`                      | An object with overrides for the Renderer's default colors.       |
+| `hideBounds`         | `boolean`                     | Do not show the bounding box for selected shapes.                 |
+| `hideHandles`        | `boolean`                     | Do not show handles for shapes with handles.                      |
+| `hideBindingHandles` | `boolean`                     | Do not show binding controls for selected shapes with bindings.   |
+| `hideResizeHandles`  | `boolean`                     | Do not show resize handles for selected shapes.                   |
+| `hideRotateHandles`  | `boolean`                     | Do not show rotate handles for selected shapes.                   |
+| `snapLines`          | [`TLSnapLine`](#tlsnapline)[] | An array of "snap" lines.                                         |
+| `users`              | `object`                      | A table of [`TLUser`](#tluser)s.                                  |
+| `userId`             | `object`                      | The current user's [`TLUser`](#tluser) id.                        |
 
 The theme object accepts valid CSS colors for the following properties:
 

--- a/packages/core/src/components/bounds/__tests__/bounds.test.tsx
+++ b/packages/core/src/components/bounds/__tests__/bounds.test.tsx
@@ -16,6 +16,7 @@ describe('bounds', () => {
         hideBindingHandles={false}
         hideCloneHandles={false}
         hideRotateHandle={false}
+        hideResizeHandles={false}
       />
     )
   })
@@ -31,6 +32,7 @@ describe('bounds', () => {
         hideBindingHandles={false}
         hideCloneHandles={false}
         hideRotateHandle={false}
+        hideResizeHandles={false}
       />
     )
 
@@ -47,4 +49,13 @@ describe('bounds', () => {
     expect(screen.getByLabelText('link handle')).toBeDefined()
     expect(screen.getByLabelText('link rotate handle')).toBeDefined()
   })
+
+  test.todo('Renders correctly when zoomed')
+  test.todo('Renders correctly when rotated')
+  test.todo('Renders correctly when locked')
+  test.todo('Renders correctly when hidden')
+  test.todo('Renders correctly when hideBindingHandles is true')
+  test.todo('Renders correctly when hideCloneHandles is true')
+  test.todo('Renders correctly when hideRotateHandle is true')
+  test.todo('Renders correctly when hideResizeHandles is true')
 })

--- a/packages/core/src/components/bounds/bounds.tsx
+++ b/packages/core/src/components/bounds/bounds.tsx
@@ -19,6 +19,7 @@ interface BoundsProps {
   hideCloneHandles: boolean
   hideRotateHandle: boolean
   hideBindingHandles: boolean
+  hideResizeHandles: boolean
   viewportWidth: number
   children?: React.ReactNode
 }
@@ -31,6 +32,7 @@ export const Bounds = React.memo(function Bounds({
   isHidden,
   isLocked,
   hideCloneHandles,
+  hideResizeHandles,
   hideRotateHandle,
   hideBindingHandles,
 }: BoundsProps): JSX.Element {
@@ -48,67 +50,73 @@ export const Bounds = React.memo(function Bounds({
   const showCornerHandles = !isHidden && !isLocked && smallDimension > 20
   // If the bounds are very small, don't show the clone handles
   const showCloneHandles = !hideCloneHandles && smallDimension > 24
+  // Unless we're hiding the resize handles, show them
+  const showResizeHandles = !hideResizeHandles && !isLocked
 
   return (
     <Container bounds={bounds} rotation={rotation}>
       <SVGContainer>
         <CenterHandle bounds={bounds} isLocked={isLocked} isHidden={isHidden} />
-        <EdgeHandle
-          targetSize={targetSize}
-          size={size}
-          bounds={bounds}
-          edge={TLBoundsEdge.Top}
-          isHidden={!showEdgeHandles}
-        />
-        <EdgeHandle
-          targetSize={targetSize}
-          size={size}
-          bounds={bounds}
-          edge={TLBoundsEdge.Right}
-          isHidden={!showEdgeHandles}
-        />
-        <EdgeHandle
-          targetSize={targetSize}
-          size={size}
-          bounds={bounds}
-          edge={TLBoundsEdge.Bottom}
-          isHidden={!showEdgeHandles}
-        />
-        <EdgeHandle
-          targetSize={targetSize}
-          size={size}
-          bounds={bounds}
-          edge={TLBoundsEdge.Left}
-          isHidden={!showEdgeHandles}
-        />
-        <CornerHandle
-          targetSize={targetSize}
-          size={size}
-          bounds={bounds}
-          isHidden={isHidden || !showCornerHandles}
-          corner={TLBoundsCorner.TopLeft}
-        />
-        <CornerHandle
-          targetSize={targetSize}
-          size={size}
-          bounds={bounds}
-          isHidden={isHidden || !showCornerHandles}
-          corner={TLBoundsCorner.TopRight}
-        />
-        <CornerHandle
-          targetSize={targetSize}
-          size={size}
-          bounds={bounds}
-          isHidden={isHidden || !showCornerHandles}
-          corner={TLBoundsCorner.BottomRight}
-        />
-        <CornerHandle
-          targetSize={targetSize}
-          size={size}
-          bounds={bounds}
-          isHidden={isHidden || !showCornerHandles}
-          corner={TLBoundsCorner.BottomLeft}
-        />
+        {showResizeHandles && (
+          <>
+            <EdgeHandle
+              targetSize={targetSize}
+              size={size}
+              bounds={bounds}
+              edge={TLBoundsEdge.Top}
+              isHidden={!showEdgeHandles}
+            />
+            <EdgeHandle
+              targetSize={targetSize}
+              size={size}
+              bounds={bounds}
+              edge={TLBoundsEdge.Right}
+              isHidden={!showEdgeHandles}
+            />
+            <EdgeHandle
+              targetSize={targetSize}
+              size={size}
+              bounds={bounds}
+              edge={TLBoundsEdge.Bottom}
+              isHidden={!showEdgeHandles}
+            />
+            <EdgeHandle
+              targetSize={targetSize}
+              size={size}
+              bounds={bounds}
+              edge={TLBoundsEdge.Left}
+              isHidden={!showEdgeHandles}
+            />
+            <CornerHandle
+              targetSize={targetSize}
+              size={size}
+              bounds={bounds}
+              isHidden={isHidden || !showCornerHandles}
+              corner={TLBoundsCorner.TopLeft}
+            />
+            <CornerHandle
+              targetSize={targetSize}
+              size={size}
+              bounds={bounds}
+              isHidden={isHidden || !showCornerHandles}
+              corner={TLBoundsCorner.TopRight}
+            />
+            <CornerHandle
+              targetSize={targetSize}
+              size={size}
+              bounds={bounds}
+              isHidden={isHidden || !showCornerHandles}
+              corner={TLBoundsCorner.BottomRight}
+            />
+            <CornerHandle
+              targetSize={targetSize}
+              size={size}
+              bounds={bounds}
+              isHidden={isHidden || !showCornerHandles}
+              corner={TLBoundsCorner.BottomLeft}
+            />
+          </>
+        )}
         {showRotateHandle && (
           <RotateHandle
             targetSize={targetSize}

--- a/packages/core/src/components/canvas/canvas.test.tsx
+++ b/packages/core/src/components/canvas/canvas.test.tsx
@@ -12,9 +12,10 @@ describe('page', () => {
         hideIndicators={false}
         hideHandles={false}
         hideBindingHandles={false}
+        hideResizeHandles={false}
         hideCloneHandles={false}
         hideRotateHandle={false}
-        onBoundsChange={(bounds) => {}}
+        onBoundsChange={() => {}}
       />
     )
   })

--- a/packages/core/src/components/canvas/canvas.tsx
+++ b/packages/core/src/components/canvas/canvas.tsx
@@ -35,6 +35,7 @@ interface CanvasProps<T extends TLShape, M extends Record<string, unknown>> {
   hideIndicators: boolean
   hideBindingHandles: boolean
   hideCloneHandles: boolean
+  hideResizeHandles: boolean
   hideRotateHandle: boolean
   externalContainerRef?: React.RefObject<HTMLElement>
   meta?: M
@@ -56,6 +57,7 @@ export function Canvas<T extends TLShape, M extends Record<string, unknown>>({
   hideIndicators,
   hideBindingHandles,
   hideCloneHandles,
+  hideResizeHandles,
   hideRotateHandle,
   onBoundsChange,
 }: CanvasProps<T, M>): JSX.Element {
@@ -92,6 +94,7 @@ export function Canvas<T extends TLShape, M extends Record<string, unknown>>({
               hideHandles={hideHandles}
               hideBindingHandles={hideBindingHandles}
               hideCloneHandles={hideCloneHandles}
+              hideResizeHandles={hideResizeHandles}
               hideRotateHandle={hideRotateHandle}
               meta={meta}
             />

--- a/packages/core/src/components/page/page.test.tsx
+++ b/packages/core/src/components/page/page.test.tsx
@@ -14,6 +14,7 @@ describe('page', () => {
         hideBindingHandles={false}
         hideCloneHandles={false}
         hideRotateHandle={false}
+        hideResizeHandles={false}
       />
     )
   })

--- a/packages/core/src/components/page/page.tsx
+++ b/packages/core/src/components/page/page.tsx
@@ -18,6 +18,7 @@ interface PageProps<T extends TLShape, M extends Record<string, unknown>> {
   hideBindingHandles: boolean
   hideCloneHandles: boolean
   hideRotateHandle: boolean
+  hideResizeHandles: boolean
   meta?: M
 }
 
@@ -33,6 +34,7 @@ export const Page = React.memo(function Page<T extends TLShape, M extends Record
   hideBindingHandles,
   hideCloneHandles,
   hideRotateHandle,
+  hideResizeHandles,
   meta,
 }: PageProps<T, M>): JSX.Element {
   const { bounds: rendererBounds, shapeUtils } = useTLContext()
@@ -93,6 +95,7 @@ export const Page = React.memo(function Page<T extends TLShape, M extends Record
           rotation={rotation}
           isHidden={hideBounds}
           hideRotateHandle={hideRotateHandle}
+          hideResizeHandles={hideResizeHandles}
           hideBindingHandles={hideBindingHandles || !isLinked}
           hideCloneHandles={_hideCloneHandles}
         />

--- a/packages/core/src/components/renderer/renderer.tsx
+++ b/packages/core/src/components/renderer/renderer.tsx
@@ -65,6 +65,10 @@ export interface RendererProps<T extends TLShape, M = any> extends Partial<TLCal
    */
   hideHandles?: boolean
   /**
+   * (optional) When true, the renderer will not show resize handles for selected objects.
+   */
+  hideResizeHandles?: boolean
+  /**
    * (optional) When true, the renderer will not show rotate handles for selected objects.
    */
   hideRotateHandles?: boolean
@@ -114,6 +118,7 @@ export function Renderer<T extends TLShape, M extends Record<string, unknown>>({
   hideIndicators = false,
   hideCloneHandles = false,
   hideBindingHandles = false,
+  hideResizeHandles = false,
   hideRotateHandles = false,
   hideBounds = false,
   ...rest
@@ -167,6 +172,7 @@ export function Renderer<T extends TLShape, M extends Record<string, unknown>>({
         hideCloneHandles={hideCloneHandles}
         hideBindingHandles={hideBindingHandles}
         hideRotateHandle={hideRotateHandles}
+        hideResizeHandles={hideResizeHandles}
         onBoundsChange={onBoundsChange}
         meta={meta}
       />


### PR DESCRIPTION
This PR adds the `hideResizeHandles` prop, which will hide the corner and edge handles of the selection bounds when the prop is `true`.